### PR TITLE
Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,7 @@ Imports:
     Rcpp (>= 0.12.0),
     RcppParallel (>= 5.0.2),
     RCurl (>= 1.98),
-    rstan (>= 2.21.2),
+    rstan (>= 2.26.0),
     rstantools (>= 2.3.1),
     bayesplot (>= 1.7.0),
     MASS (>= 7.3-50),
@@ -44,8 +44,8 @@ LinkingTo:
     Rcpp (>= 1.0.6),
     RcppEigen (>= 0.3.3.9.1),
     RcppParallel (>= 5.0.2),
-    rstan (>= 2.21.2),
-    StanHeaders (>= 2.21.0-7)
+    rstan (>= 2.26.0),
+    StanHeaders (>= 2.26.0)
 SystemRequirements: GNU make
 NeedsCompilation: yes
 RoxygenNote: 7.2.3

--- a/inst/stan/_common/data-covariates.stan
+++ b/inst/stan/_common/data-covariates.stan
@@ -1,11 +1,11 @@
   // Covariates
-  vector[num_obs] x_cont[num_cov_cont];
-  vector[num_obs] x_cont_unnorm[num_cov_cont];
-  int x_cont_mask[num_cov_cont, num_obs];
-  int x_cat[num_cov_cat, num_obs];
+  array[num_cov_cont] vector[num_obs] x_cont;
+  array[num_cov_cont] vector[num_obs] x_cont_unnorm;
+  array[num_cov_cont, num_obs] int x_cont_mask;
+  array[num_cov_cat, num_obs] int x_cat;
   
   // Expanding beta or teff to a vector of length equal to num_obs.
   // The value idx_expand[j]-1 tells the index of the beta or teff parameter
   // that should be used for observation j. If observation j doesn't
   //  correspond to any beta parameter, then idx_expand[j] should be 1.
-  int<lower=1, upper=num_bt+1> idx_expand[num_obs];
+  array[num_obs] int<lower=1, upper=num_bt+1> idx_expand;

--- a/inst/stan/_common/data-general.stan
+++ b/inst/stan/_common/data-general.stan
@@ -38,14 +38,14 @@
       * kernel 0 = zero-sum kernel * [exp. quadratic]
       * kernel 1 = categorical kernel * [exp. quadratic]
   */
-  int<lower=0> components[num_comps, 9];
+  array[num_comps, 9] int<lower=0> components;
 
   // Observed effect times and uncertainty bounds for each case subject
-  vector[num_bt] teff_zero[num_uncrt>0];
-  vector[num_bt] teff_lb[num_uncrt>0];
-  vector[num_bt] teff_ub[num_uncrt>0];
+  array[num_uncrt>0] vector[num_bt] teff_zero;
+  array[num_uncrt>0] vector[num_bt] teff_lb;
+  array[num_uncrt>0] vector[num_bt] teff_ub;
 
   // Misc
-  int<lower=0> x_cat_num_levels[num_cov_cat];
+  array[num_cov_cat] int<lower=0> x_cat_num_levels;
   real delta; // jitter to ensure pos. def. kernel matrices
-  real vm_params[2]; // variance mask parameters (nonstat comps)
+  array[2] real vm_params; // variance mask parameters (nonstat comps)

--- a/inst/stan/_common/data-priors.stan
+++ b/inst/stan/_common/data-priors.stan
@@ -1,10 +1,10 @@
   // Priors types and hyperparameters
-  int<lower=0> prior_alpha[num_comps, 2];  // {prior_type, transform}
-  int<lower=0> prior_ell[num_ell, 2];      // {prior_type, transform}
-  int<lower=0> prior_wrp[num_ns, 2];       // {prior_type, transform}
-  int<lower=0> prior_teff[num_uncrt>0, 2]; // {prior type, is_backwards}
-  real hyper_alpha[num_comps, 3];
-  real hyper_ell[num_ell, 3];
-  real hyper_wrp[num_ns, 3];
-  real hyper_teff[num_uncrt>0, 3];
-  real hyper_beta[num_heter>0, 2];
+  array[num_comps, 2] int<lower=0> prior_alpha;  // {prior_type, transform}
+  array[num_ell, 2] int<lower=0> prior_ell;      // {prior_type, transform}
+  array[num_ns, 2] int<lower=0> prior_wrp;       // {prior_type, transform}
+  array[num_uncrt>0, 2] int<lower=0> prior_teff; // {prior type, is_backwards}
+  array[num_comps, 3] real hyper_alpha;
+  array[num_ell, 3] real hyper_ell;
+  array[num_ns, 3] real hyper_wrp;
+  array[num_uncrt>0, 3] real hyper_teff;
+  array[num_heter>0, 2] real hyper_beta;

--- a/inst/stan/_common/functions-basisfun.stan
+++ b/inst/stan/_common/functions-basisfun.stan
@@ -88,11 +88,11 @@
   
   // Compute num_comps basis function matrices Phi, which each have shape
   // [num_obs, num_basisfun]
-  matrix[] STAN_phi_matrix(data vector[] x, data int M, data real L, 
-      data int[,] components){
+  array[] matrix STAN_phi_matrix(data array[] vector x, data int M, data real L, 
+      data array[,] int components){
     int n = num_elements(x[1]);
     int J = size(components);
-    matrix[n, M] PHI[J];
+    array[J] matrix[n, M] PHI;
     for(j in 1:J) {
       matrix[n, M] PHI_j = rep_matrix(1.0, n, M); //
       if(components[j,1] > 0) {
@@ -108,10 +108,10 @@
   }
   
   // Compute diagonals of diagonal matrices Lambda
-  vector[] STAN_lambda_matrix(real[] ell, data int M, data real L,
-      data int[,] components){
+  array[] vector STAN_lambda_matrix(array[] real ell, data int M, data real L,
+      data array[,] int components){
     int J = size(components);
-    vector[M] Lambda[J];
+    array[J] vector[M] Lambda;
     int j_ell = 0;
     for(j in 1:J) {
       if (components[j,1] > 0) {
@@ -127,9 +127,9 @@
   }
   
   // Get ranks of the constant kernel matrices
-  int[] STAN_ranks(data int[,] components, data int[] x_cat_num_levels){
+  array[] int STAN_ranks(data array[,] int components, data array[] int x_cat_num_levels){
     int J = size(components);
-    int ranks[J] = rep_array(1, J);
+    array[J] int ranks = rep_array(1, J);
     for (j in 1:J) {
       int idx_cat = components[j,8];
       if (idx_cat > 0) {
@@ -140,8 +140,8 @@
   }
   
   // Compute diagonals of Delta
-  vector STAN_delta_matrix(data matrix[] K_const, data int[] ranks, 
-      data int[,] components){
+  vector STAN_delta_matrix(data array[] matrix K_const, data array[] int ranks, 
+      data array[,] int components){
     int J = size(ranks);
     int n = cols(K_const[1]);
     int R = sum(ranks);
@@ -161,8 +161,8 @@
   }
   
   // Compute eigenvector matrix Theta
-  matrix STAN_theta_matrix(data matrix[] K_const, data int[] ranks,
-      data int[,] components){
+  matrix STAN_theta_matrix(data array[] matrix K_const, data array[] int ranks,
+      data array[,] int components){
     int J = size(ranks);
     int n = cols(K_const[1]);
     int R = sum(ranks);
@@ -184,8 +184,8 @@
   // Create D, a vector of length num_basisfun*sum(ranks)
   // - bfa_lambda = a an array of num_comps vectors of shape [num_basisfun]
   // - bfa_delta = a vector of shape [R]
-  vector STAN_D_matrix(real[] alpha, vector[] bfa_lambda, 
-      vector bfa_delta, int[] ranks) {
+  vector STAN_D_matrix(array[] real alpha, array[] vector bfa_lambda, 
+      vector bfa_delta, array[] int ranks) {
     int M = num_elements(bfa_lambda[1]);
     int RM = sum(ranks)*M;
     int J = size(ranks);
@@ -208,7 +208,7 @@
   // - bfa_phi = array of matrices with shape [num_obs, num_basisfun], length 
   //     num_comps
   // - bfa_theta = matrix of shape [num_obs, R]
-  matrix STAN_V_matrix(matrix[] bfa_phi, matrix bfa_theta, int[] ranks) {
+  matrix STAN_V_matrix(array[] matrix bfa_phi, matrix bfa_theta, array[] int ranks) {
     int J = size(bfa_phi);
     int n = rows(bfa_phi[1]);
     int M = cols(bfa_phi[1]);

--- a/inst/stan/_common/functions-kernels.stan
+++ b/inst/stan/_common/functions-kernels.stan
@@ -1,5 +1,5 @@
   // Categorical zero-sum kernel
-  matrix STAN_kernel_zerosum(data int[] x1, data int[] x2, data int num_cat) {
+  matrix STAN_kernel_zerosum(data array[] int x1, data array[] int x2, data int num_cat) {
     int n1 = size(x1); 
     int n2 = size(x2);
     matrix[n1, n2] K;
@@ -16,7 +16,7 @@
   }
   
   // Categorical kernel
-  matrix STAN_kernel_cat(data int[] x1, data int[] x2) {
+  matrix STAN_kernel_cat(data array[] int x1, data array[] int x2) {
     int n1 = size(x1);
     int n2 = size(x2);
     matrix[n1,n2] K;
@@ -29,7 +29,7 @@
   }
   
   // Binary mask kernel
-  matrix STAN_kernel_bin(data int[] x1, data int[] x2) {
+  matrix STAN_kernel_bin(data array[] int x1, data array[] int x2) {
     int n1 = size(x1);
     int n2 = size(x2);
     matrix[n1,n2] K;
@@ -43,7 +43,7 @@
   
   // Compute one constant kernel matrix. Does not depend on parameters and
   // therefore this function never needs to be evaluated during sampling.
-  matrix STAN_kernel_const(data int[] x1, data int[] x2, 
+  matrix STAN_kernel_const(data array[] int x1, data array[] int x2, 
     data int kernel_type,  data int ncat) 
   {
     int n1 = num_elements(x1);
@@ -62,17 +62,17 @@
   
   // Compute all constant kernel matrices. These do not depend on parameters and
   // therefore this function never needs to be evaluated during sampling.
-  matrix[] STAN_kernel_const_all(
+  array[] matrix STAN_kernel_const_all(
     data int n1,           data int n2,
-    data int[,] x1,        data int[,] x2,
-    data int[,] x1_mask,   data int[,] x2_mask,
-    data int[] num_levels, data int[,] components)
+    data array[,] int x1,        data array[,] int x2,
+    data array[,] int x1_mask,   data array[,] int x2_mask,
+    data array[] int num_levels, data array[,] int components)
   {
     int num_comps = size(components);
-    matrix[n1, n2] K_const[num_comps];
+    array[num_comps] matrix[n1, n2] K_const;
     for (j in 1:num_comps) {
       matrix[n1, n2] K;
-      int opts[9] = components[j];
+      array[9] int opts = components[j];
       int ctype = opts[1];
       int ktype = opts[2];
       int idx_cat = opts[8];
@@ -97,12 +97,12 @@
   
   // Exponentiated quadratic kernel (with vector inputs)
   matrix STAN_kernel_eq(vector x1, vector x2, real alpha, real ell) {
-    return(cov_exp_quad(to_array_1d(x1), to_array_1d(x2), alpha, ell));
+    return(gp_exp_quad_cov(to_array_1d(x1), to_array_1d(x2), alpha, ell));
   }
   
   // Multiplier matrix to enable variance masking
   matrix STAN_kernel_varmask(vector x1, vector x2, 
-    real steepness, data real[] vm_params) 
+    real steepness, data array[] real vm_params) 
   {
     real a = steepness * vm_params[2];
     real r = inv(a)*logit(vm_params[1]);
@@ -113,7 +113,7 @@
   }
   
   // Multiplier matrix to enable heterogeneous effects
-  matrix STAN_kernel_beta(vector beta, int[] idx1_expand, int[] idx2_expand) {
+  matrix STAN_kernel_beta(vector beta, array[] int idx1_expand, array[] int idx2_expand) {
     return(
       to_matrix(STAN_expand(sqrt(beta), idx1_expand)) *
       transpose(to_matrix(STAN_expand(sqrt(beta), idx2_expand)))
@@ -124,30 +124,30 @@
     Compute all kernel matrices. These depend on parameters and
     therefore this function needs to be evaluated repeatedly during sampling.
   */
-  matrix[] STAN_kernel_all(
+  array[] matrix STAN_kernel_all(
     data int n1,
     data int n2,
-    data matrix[] K_const,
-    data int[,] components,
-    data vector[] x1,
-    data vector[] x2,
-    data vector[] x1_unnorm,
-    data vector[] x2_unnorm,
-    real[] alpha,
-    real[] ell,
-    real[] wrp,
-    vector[] beta,
-    vector[] teff,
-    data real[] vm_params,
-    data int[] idx1_expand,
-    data int[] idx2_expand,
-    data vector[] teff_zero)
+    data array[] matrix K_const,
+    data array[,] int components,
+    data array[] vector x1,
+    data array[] vector x2,
+    data array[] vector x1_unnorm,
+    data array[] vector x2_unnorm,
+    array[] real alpha,
+    array[] real ell,
+    array[] real wrp,
+    array[] vector beta,
+    array[] vector teff,
+    data array[] real vm_params,
+    data array[] int idx1_expand,
+    data array[] int idx2_expand,
+    data array[] vector teff_zero)
   {
     int idx_ell = 0;
     int idx_wrp = 0;
     int idx_alpha = 0;
     int num_comps = size(components);
-    matrix[n1, n2] KX[num_comps];
+    array[num_comps] matrix[n1, n2] KX;
   
     // Loop through components
     for(j in 1:num_comps){
@@ -158,7 +158,7 @@
       vector[n2] X2;
   
       // 2. Get component properties
-      int opts[9] = components[j];
+      array[9] int opts = components[j];
       int ctype = opts[1];
       int idx_cont = opts[9];
       int is_heter = opts[4];

--- a/inst/stan/_common/functions-kernels_diag.stan
+++ b/inst/stan/_common/functions-kernels_diag.stan
@@ -2,7 +2,7 @@
 // prediction computations.
 
   // Compute one constant kernel matrix diagonal.
-  vector STAN_kernel_const_diag(data int[] x, data int kernel_type) 
+  vector STAN_kernel_const_diag(data array[] int x, data int kernel_type) 
   {
     int n = num_elements(x);
     vector[n] K_diag = rep_vector(1.0, n);
@@ -17,17 +17,17 @@
   }
   
   // Compute all constant kernel matrices' diagonals.
-  vector[] STAN_kernel_const_all_diag(
+  array[] vector STAN_kernel_const_all_diag(
     data int n,
-    data int[,] x,
-    data int[,] x_mask,  
-    data int[,] components)
+    data array[,] int x,
+    data array[,] int x_mask,  
+    data array[,] int components)
   {
     int num_comps = size(components);
-    vector[n] K_const_diag[num_comps];
+    array[num_comps] vector[n] K_const_diag;
     for (j in 1:num_comps) {
       vector[n] K_diag;
-      int opts[9] = components[j];
+      array[9] int opts = components[j];
       int ctype = opts[1];
       int ktype = opts[2];
       int idx_cat = opts[8];
@@ -56,7 +56,7 @@
   
   // Multiplier matrix to enable variance masking
   vector STAN_kernel_varmask_diag(vector x, real steepness,
-    data real[] vm_params)
+    data array[] real vm_params)
   {
     real a = steepness * vm_params[2];
     real r = inv(a)*logit(vm_params[1]);
@@ -66,31 +66,31 @@
   }
   
   // Multiplier matrix to enable heterogeneous effects
-  vector STAN_kernel_beta_diag(vector beta, int[] idx_expand) {
+  vector STAN_kernel_beta_diag(vector beta, array[] int idx_expand) {
     return(STAN_expand(beta, idx_expand));
   }
   
   /* 
     Compute diagonals of all kernel matrices.
   */
-  vector[] STAN_kernel_all_diag(
+  array[] vector STAN_kernel_all_diag(
     data int n,
-    data vector[] K_const_diag,
-    data int[,] components,
-    data vector[] x,
-    data vector[] x_unnorm,
-    real[] alpha,
-    real[] wrp,
-    vector[] beta,
-    vector[] teff,
-    data real[] vm_params,
-    data int[] idx_expand,
-    data vector[] teff_zero)
+    data array[] vector K_const_diag,
+    data array[,] int components,
+    data array[] vector x,
+    data array[] vector x_unnorm,
+    array[] real alpha,
+    array[] real wrp,
+    array[] vector beta,
+    array[] vector teff,
+    data array[] real vm_params,
+    data array[] int idx_expand,
+    data array[] vector teff_zero)
   {
     int idx_wrp = 0;
     int idx_alpha = 0;
     int num_comps = size(components);
-    vector[n] KX_diag[num_comps];
+    array[num_comps] vector[n] KX_diag;
   
     // Loop through components
     for(j in 1:num_comps){
@@ -100,7 +100,7 @@
       vector[n] X;
   
       // 2. Get component properties
-      int opts[9] = components[j];
+      array[9] int opts = components[j];
       int ctype = opts[1];
       int idx_cont = opts[9];
       int is_heter = opts[4];

--- a/inst/stan/_common/functions-prior.stan
+++ b/inst/stan/_common/functions-prior.stan
@@ -1,11 +1,11 @@
   // Log prior density to be added to target
-  real STAN_log_prior(real x, data int[] types, data real[] p) {
+  real STAN_log_prior(real x, data array[] int types, data array[] real p) {
     real log_prior = 0;
     real t = x;
   
     // Possible transform and log of its absolute derivative
     if (types[2]==1){
-      log_prior += log(fabs(2*x));
+      log_prior += log(abs(2*x));
       t = square(x);
     }
     

--- a/inst/stan/_common/functions-utils.stan
+++ b/inst/stan/_common/functions-utils.stan
@@ -1,5 +1,5 @@
   // Compute total signal by summing components
-  vector STAN_vectorsum(vector[] vecs, data int L){
+  vector STAN_vectorsum(array[] vector vecs, data int L){
     int num_vecs = size(vecs);
     vector[L] s = rep_vector(0, L);
     for (j in 1:num_vecs){
@@ -9,7 +9,7 @@
   }
   
   // Sum an array of matrices
-  matrix STAN_matrix_array_sum(matrix[] K){
+  matrix STAN_matrix_array_sum(array[] matrix K){
     int n1 = rows(K[1]);
     int n2 = cols(K[1]);
     matrix[n1, n2] K_sum = K[1];
@@ -30,7 +30,7 @@
   }
   
   // Expand a vector
-  vector STAN_expand(vector v, data int[] idx_expand){
+  vector STAN_expand(vector v, data array[] int idx_expand){
     int L = num_elements(v);
     vector[L+1] v_add0 = rep_vector(0.0, L+1);
     v_add0[2:(L+1)] = v;
@@ -40,7 +40,7 @@
   // Edit a continuous covariate according to sampled uncertainty
   vector STAN_edit_x_cont(
     vector x_cont,
-    data int[] idx_expand,
+    data array[] int idx_expand,
     data vector teff_obs,
     vector teff)
   {

--- a/inst/stan/_common/params.stan
+++ b/inst/stan/_common/params.stan
@@ -1,5 +1,5 @@
-  real<lower=1e-12> alpha[num_comps];
-  real<lower=1e-12> ell[num_ell];
-  real<lower=1e-12> wrp[num_ns];
-  vector<lower=1e-12, upper=1-1e-12>[num_bt] beta[num_heter>0];
-  vector<lower=1e-12, upper=1-1e-12>[num_bt] teff_raw[num_uncrt>0];
+  array[num_comps] real<lower=1e-12> alpha;
+  array[num_ell] real<lower=1e-12> ell;
+  array[num_ns] real<lower=1e-12> wrp;
+  array[num_heter>0] vector<lower=1e-12, upper=1-1e-12>[num_bt] beta;
+  array[num_uncrt>0] vector<lower=1e-12, upper=1-1e-12>[num_bt] teff_raw;

--- a/inst/stan/_common/tdata.stan
+++ b/inst/stan/_common/tdata.stan
@@ -1,5 +1,5 @@
   // Precompute fixed kernel matrices
-  matrix[num_obs, num_obs] K_const[num_comps] = STAN_kernel_const_all(
+  array[num_comps] matrix[num_obs, num_obs] K_const = STAN_kernel_const_all(
     num_obs, num_obs, x_cat, x_cat, x_cont_mask, x_cont_mask, 
     x_cat_num_levels, components
   );

--- a/inst/stan/_common/tparams.stan
+++ b/inst/stan/_common/tparams.stan
@@ -1,5 +1,5 @@
   // Transform raw effect times
-  vector[num_bt] teff[num_uncrt>0];
+  array[num_uncrt>0] vector[num_bt] teff;
   for(j in 1:num_uncrt){
     teff[j] = teff_lb[j] + (teff_ub[j] - teff_lb[j]) .* teff_raw[j];
   }

--- a/inst/stan/exports.stanfunctions
+++ b/inst/stan/exports.stanfunctions
@@ -5,7 +5,7 @@ functions {
   }
 
   // Expand a vector
-  vector STAN_expand(vector v, data int[] idx_expand){
+  vector STAN_expand(vector v, data array[] int idx_expand){
     int L = num_elements(v);
     vector[L+1] v_add0 = rep_vector(0.0, L+1);
     v_add0[2:(L+1)] = v;
@@ -20,7 +20,7 @@ functions {
     // Edit a continuous covariate according to sampled uncertainty
   vector STAN_edit_x_cont(
     vector x_cont,
-    data int[] idx_expand,
+    data array[] int idx_expand,
     data vector teff_obs,
     vector teff)
   {
@@ -31,7 +31,7 @@ functions {
   }
 
   // Compute one constant kernel matrix diagonal.
-  vector STAN_kernel_const_diag(data int[] x, data int kernel_type)
+  vector STAN_kernel_const_diag(data array[] int x, data int kernel_type)
   {
     int n = num_elements(x);
     vector[n] K_diag = rep_vector(1.0, n);
@@ -46,17 +46,17 @@ functions {
   }
 
   // Compute all constant kernel matrices' diagonals.
-  vector[] STAN_kernel_const_all_diag(
+  array[] vector STAN_kernel_const_all_diag(
     data int n,
-    data int[,] x,
-    data int[,] x_mask,
-    data int[,] components)
+    data array[,] int x,
+    data array[,] int x_mask,
+    data array[,] int components)
   {
     int num_comps = size(components);
-    vector[n] K_const_diag[num_comps];
+    array[num_comps] vector[n] K_const_diag;
     for (j in 1:num_comps) {
       vector[n] K_diag;
-      int opts[9] = components[j];
+      array[9] int opts = components[j];
       int ctype = opts[1];
       int ktype = opts[2];
       int idx_cat = opts[8];
@@ -85,7 +85,7 @@ functions {
 
   // Multiplier matrix to enable variance masking
   vector STAN_kernel_varmask_diag(vector x, real steepness,
-    data real[] vm_params)
+    data array[] real vm_params)
   {
     real a = steepness * vm_params[2];
     real r = inv(a)*logit(vm_params[1]);
@@ -95,31 +95,31 @@ functions {
   }
 
   // Multiplier matrix to enable heterogeneous effects
-  vector STAN_kernel_beta_diag(vector beta, int[] idx_expand) {
+  vector STAN_kernel_beta_diag(vector beta, array[] int idx_expand) {
     return(STAN_expand(beta, idx_expand));
   }
 
   /*
     Compute diagonals of all kernel matrices.
   */
-  vector[] STAN_kernel_all_diag(
+  array[] vector STAN_kernel_all_diag(
     data int n,
-    data vector[] K_const_diag,
-    data int[,] components,
-    data vector[] x,
-    data vector[] x_unnorm,
-    real[] alpha,
-    real[] wrp,
-    vector[] beta,
-    vector[] teff,
-    data real[] vm_params,
-    data int[] idx_expand,
-    data vector[] teff_zero)
+    data array[] vector K_const_diag,
+    data array[,] int components,
+    data array[] vector x,
+    data array[] vector x_unnorm,
+    array[] real alpha,
+    array[] real wrp,
+    array[] vector beta,
+    array[] vector teff,
+    data array[] real vm_params,
+    data array[] int idx_expand,
+    data array[] vector teff_zero)
   {
     int idx_wrp = 0;
     int idx_alpha = 0;
     int num_comps = size(components);
-    vector[n] KX_diag[num_comps];
+    array[num_comps] vector[n] KX_diag;
 
     // Loop through components
     for(j in 1:num_comps){
@@ -129,7 +129,7 @@ functions {
       vector[n] X;
 
       // 2. Get component properties
-      int opts[9] = components[j];
+      array[9] int opts = components[j];
       int ctype = opts[1];
       int idx_cont = opts[9];
       int is_heter = opts[4];
@@ -186,7 +186,7 @@ functions {
   }
 
   // Categorical zero-sum kernel
-  matrix STAN_kernel_zerosum(data int[] x1, data int[] x2, data int num_cat) {
+  matrix STAN_kernel_zerosum(data array[] int x1, data array[] int x2, data int num_cat) {
     int n1 = size(x1);
     int n2 = size(x2);
     matrix[n1, n2] K;
@@ -203,7 +203,7 @@ functions {
   }
 
   // Categorical kernel
-  matrix STAN_kernel_cat(data int[] x1, data int[] x2) {
+  matrix STAN_kernel_cat(data array[] int x1, data array[] int x2) {
     int n1 = size(x1);
     int n2 = size(x2);
     matrix[n1,n2] K;
@@ -216,7 +216,7 @@ functions {
   }
 
   // Binary mask kernel
-  matrix STAN_kernel_bin(data int[] x1, data int[] x2) {
+  matrix STAN_kernel_bin(data array[] int x1, data array[] int x2) {
     int n1 = size(x1);
     int n2 = size(x2);
     matrix[n1,n2] K;
@@ -230,7 +230,7 @@ functions {
 
   // Compute one constant kernel matrix. Does not depend on parameters and
   // therefore this function never needs to be evaluated during sampling.
-  matrix STAN_kernel_const(data int[] x1, data int[] x2,
+  matrix STAN_kernel_const(data array[] int x1, data array[] int x2,
     data int kernel_type,  data int ncat)
   {
     int n1 = num_elements(x1);
@@ -249,17 +249,17 @@ functions {
 
   // Compute all constant kernel matrices. These do not depend on parameters and
   // therefore this function never needs to be evaluated during sampling.
-  matrix[] STAN_kernel_const_all(
+  array[] matrix STAN_kernel_const_all(
     data int n1,           data int n2,
-    data int[,] x1,        data int[,] x2,
-    data int[,] x1_mask,   data int[,] x2_mask,
-    data int[] num_levels, data int[,] components)
+    data array[,] int x1,        data array[,] int x2,
+    data array[,] int x1_mask,   data array[,] int x2_mask,
+    data array[] int num_levels, data array[,] int components)
   {
     int num_comps = size(components);
-    matrix[n1, n2] K_const[num_comps];
+    array[num_comps] matrix[n1, n2] K_const;
     for (j in 1:num_comps) {
       matrix[n1, n2] K;
-      int opts[9] = components[j];
+      array[9] int opts = components[j];
       int ctype = opts[1];
       int ktype = opts[2];
       int idx_cat = opts[8];
@@ -284,12 +284,12 @@ functions {
 
   // Exponentiated quadratic kernel (with vector inputs)
   matrix STAN_kernel_eq(vector x1, vector x2, real alpha, real ell) {
-    return(cov_exp_quad(to_array_1d(x1), to_array_1d(x2), alpha, ell));
+    return(gp_exp_quad_cov(to_array_1d(x1), to_array_1d(x2), alpha, ell));
   }
 
   // Multiplier matrix to enable variance masking
   matrix STAN_kernel_varmask(vector x1, vector x2,
-    real steepness, data real[] vm_params)
+    real steepness, data array[] real vm_params)
   {
     real a = steepness * vm_params[2];
     real r = inv(a)*logit(vm_params[1]);
@@ -300,7 +300,7 @@ functions {
   }
 
   // Multiplier matrix to enable heterogeneous effects
-  matrix STAN_kernel_beta(vector beta, int[] idx1_expand, int[] idx2_expand) {
+  matrix STAN_kernel_beta(vector beta, array[] int idx1_expand, array[] int idx2_expand) {
     return(
       to_matrix(STAN_expand(sqrt(beta), idx1_expand)) *
       transpose(to_matrix(STAN_expand(sqrt(beta), idx2_expand)))
@@ -311,30 +311,30 @@ functions {
     Compute all kernel matrices. These depend on parameters and
     therefore this function needs to be evaluated repeatedly during sampling.
   */
-  matrix[] STAN_kernel_all(
+  array[] matrix STAN_kernel_all(
     data int n1,
     data int n2,
-    data matrix[] K_const,
-    data int[,] components,
-    data vector[] x1,
-    data vector[] x2,
-    data vector[] x1_unnorm,
-    data vector[] x2_unnorm,
-    real[] alpha,
-    real[] ell,
-    real[] wrp,
-    vector[] beta,
-    vector[] teff,
-    data real[] vm_params,
-    data int[] idx1_expand,
-    data int[] idx2_expand,
-    data vector[] teff_zero)
+    data array[] matrix K_const,
+    data array[,] int components,
+    data array[] vector x1,
+    data array[] vector x2,
+    data array[] vector x1_unnorm,
+    data array[] vector x2_unnorm,
+    array[] real alpha,
+    array[] real ell,
+    array[] real wrp,
+    array[] vector beta,
+    array[] vector teff,
+    data array[] real vm_params,
+    data array[] int idx1_expand,
+    data array[] int idx2_expand,
+    data array[] vector teff_zero)
   {
     int idx_ell = 0;
     int idx_wrp = 0;
     int idx_alpha = 0;
     int num_comps = size(components);
-    matrix[n1, n2] KX[num_comps];
+    array[num_comps] matrix[n1, n2] KX;
 
     // Loop through components
     for(j in 1:num_comps){
@@ -345,7 +345,7 @@ functions {
       vector[n2] X2;
 
       // 2. Get component properties
-      int opts[9] = components[j];
+      array[9] int opts = components[j];
       int ctype = opts[1];
       int idx_cont = opts[9];
       int is_heter = opts[4];
@@ -407,13 +407,13 @@ functions {
   }
 
   // Log prior density to be added to target
-  real STAN_log_prior(real x, data int[] types, data real[] p) {
+  real STAN_log_prior(real x, data array[] int types, data array[] real p) {
     real log_prior = 0;
     real t = x;
 
     // Possible transform and log of its absolute derivative
     if (types[2]==1){
-      log_prior += log(fabs(2*x));
+      log_prior += log(abs(2*x));
       t = square(x);
     }
 
@@ -434,7 +434,7 @@ functions {
   }
 
   // Compute total signal by summing components
-  vector STAN_vectorsum(vector[] vecs, data int L){
+  vector STAN_vectorsum(array[] vector vecs, data int L){
     int num_vecs = size(vecs);
     vector[L] s = rep_vector(0, L);
     for (j in 1:num_vecs){
@@ -444,7 +444,7 @@ functions {
   }
 
   // Sum an array of matrices
-  matrix STAN_matrix_array_sum(matrix[] K){
+  matrix STAN_matrix_array_sum(array[] matrix K){
     int n1 = rows(K[1]);
     int n2 = cols(K[1]);
     matrix[n1, n2] K_sum = K[1];

--- a/inst/stan/lgp.stan
+++ b/inst/stan/lgp.stan
@@ -11,8 +11,8 @@ data {
 #include _common/data-covariates.stan
 #include _common/data-priors.stan
   vector[num_obs] y_norm;
-  int<lower=0> prior_sigma[1, 2];
-  real hyper_sigma[1, 3];
+  array[1, 2] int<lower=0> prior_sigma;
+  array[1, 3] real hyper_sigma;
 }
 
 transformed data{
@@ -22,7 +22,7 @@ transformed data{
 
 parameters {
 #include _common/params.stan
-  real<lower=1e-12> sigma[1];
+  array[1] real<lower=1e-12> sigma;
 }
 
 transformed parameters {
@@ -37,7 +37,7 @@ model {
   // Likelihood
   if (is_likelihood_skipped == 0) {
     matrix[num_obs, num_obs] Ky = diag_matrix(delta_vec);
-    matrix[num_obs, num_obs] KX[num_comps] = STAN_kernel_all(num_obs, num_obs,
+    array[num_comps] matrix[num_obs, num_obs] KX = STAN_kernel_all(num_obs, num_obs,
       K_const, components, x_cont, x_cont, x_cont_unnorm, x_cont_unnorm,
       alpha, ell, wrp, beta, teff,
       vm_params, idx_expand, idx_expand, teff_zero

--- a/inst/stan/lgp_latent.stan
+++ b/inst/stan/lgp_latent.stan
@@ -11,14 +11,14 @@ data {
 #include _common/data-covariates.stan
 #include _common/data-priors.stan
   int<lower=1,upper=5> obs_model; // 1-5: Gaussian, Poisson, NB, Bin, BB
-  int<lower=0> y_int[obs_model>1, num_obs]; // response variable (int)
-  real y_real[obs_model==1, num_obs]; // response variable (real)
-  int<lower=1> y_num_trials[obs_model>3, num_obs]; // for Bin or BB model
-  int<lower=0> prior_sigma[obs_model==1, 2];
-  int<lower=0> prior_phi[obs_model==3, 2];
-  real hyper_sigma[obs_model==1, 3];
-  real hyper_phi[obs_model==3, 3];
-  real hyper_gamma[obs_model==5, 2];
+  array[obs_model>1, num_obs] int<lower=0> y_int; // response variable (int)
+  array[obs_model==1, num_obs] real y_real; // response variable (real)
+  array[obs_model>3, num_obs] int<lower=1> y_num_trials; // for Bin or BB model
+  array[obs_model==1, 2] int<lower=0> prior_sigma;
+  array[obs_model==3, 2] int<lower=0> prior_phi;
+  array[obs_model==1, 3] real hyper_sigma;
+  array[obs_model==3, 3] real hyper_phi;
+  array[obs_model==5, 2] real hyper_gamma;
   vector[num_obs] c_hat; // GP mean vector
 }
 
@@ -28,18 +28,18 @@ transformed data{
 
 parameters {
 #include _common/params.stan
-  real<lower=1e-12> sigma[obs_model==1];
-  real<lower=1e-12> phi[obs_model==3];
-  real<lower=1e-12, upper=1-1e-12> gamma[obs_model==5];
-  vector[num_obs] eta[num_comps]; // isotropic versions of func components
+  array[obs_model==1] real<lower=1e-12> sigma;
+  array[obs_model==3] real<lower=1e-12> phi;
+  array[obs_model==5] real<lower=1e-12, upper=1-1e-12> gamma;
+  array[num_comps] vector[num_obs] eta; // isotropic versions of func components
 }
 
 transformed parameters {
-  vector[num_obs] f_latent[num_comps];
+  array[num_comps] vector[num_obs] f_latent;
 #include _common/tparams.stan
   {
     matrix[num_obs, num_obs] Delta = diag_matrix(delta_vec);
-    matrix[num_obs, num_obs] KX[num_comps] = STAN_kernel_all(
+    array[num_comps] matrix[num_obs, num_obs] KX = STAN_kernel_all(
       num_obs, num_obs, K_const, components, 
       x_cont, x_cont, x_cont_unnorm, x_cont_unnorm,
       alpha, ell, wrp, beta, teff, 
@@ -68,27 +68,27 @@ model {
   // Likelihood
   if(obs_model==1 && is_likelihood_skipped==0) {
     // 1. Gaussian
-    real MU[num_obs] = to_array_1d(f_sum); // means
+    array[num_obs] real MU = to_array_1d(f_sum); // means
     target += normal_lpdf(y_real[1] | MU, sigma[1]);
   }else if(obs_model==2 && is_likelihood_skipped==0){
     // 2. Poisson
-    real LOG_MU[num_obs] = to_array_1d(f_sum); // means (log-scale)
+    array[num_obs] real LOG_MU = to_array_1d(f_sum); // means (log-scale)
     target += poisson_log_lpmf(y_int[1] | LOG_MU);
   }else if(obs_model==3 && is_likelihood_skipped==0){
     // 3. Negative binomial
-    real LOG_MU[num_obs] = to_array_1d(f_sum); // means (log-scale)
-    real PHI[num_obs] = to_array_1d(rep_vector(phi[1], num_obs)); // dispersion
+    array[num_obs] real LOG_MU = to_array_1d(f_sum); // means (log-scale)
+    array[num_obs] real PHI = to_array_1d(rep_vector(phi[1], num_obs)); // dispersion
     target += neg_binomial_2_log_lpmf(y_int[1] | LOG_MU, PHI);
   }else if(obs_model==4 && is_likelihood_skipped==0){
     // 4. Binomial
-    real LOGIT_P[num_obs] = to_array_1d(f_sum); // p success (logit-scale)
+    array[num_obs] real LOGIT_P = to_array_1d(f_sum); // p success (logit-scale)
     target += binomial_logit_lpmf(y_int[1] | y_num_trials[1], LOGIT_P);
   }else if(obs_model==5 && is_likelihood_skipped==0){
     // 5. Beta-binomial
     real tgam = inv(gamma[1]) - 1.0;
     vector[num_obs] P = inv_logit(f_sum); // p success
-    real aa[num_obs] = to_array_1d(P * tgam);
-    real bb[num_obs] = to_array_1d((1.0 - P) * tgam);
+    array[num_obs] real aa = to_array_1d(P * tgam);
+    array[num_obs] real bb = to_array_1d((1.0 - P) * tgam);
     target += beta_binomial_lpmf(y_int[1] | y_num_trials[1], aa, bb);
   }
 }

--- a/inst/stan/parameter_prior.stan
+++ b/inst/stan/parameter_prior.stan
@@ -9,18 +9,18 @@ data {
 #include _common/data-covariates.stan
 #include _common/data-priors.stan
   int<lower=1,upper=5> obs_model; // 1-5: Gaussian, Poisson, NB, Bin, BB
-  int<lower=0> prior_sigma[obs_model==1, 2];
-  int<lower=0> prior_phi[obs_model==3, 2];
-  real hyper_sigma[obs_model==1, 3];
-  real hyper_phi[obs_model==3, 3];
-  real hyper_gamma[obs_model==5, 2];
+  array[obs_model==1, 2] int<lower=0> prior_sigma;
+  array[obs_model==3, 2] int<lower=0> prior_phi;
+  array[obs_model==1, 3] real hyper_sigma;
+  array[obs_model==3, 3] real hyper_phi;
+  array[obs_model==5, 2] real hyper_gamma;
 }
 
 parameters {
 #include _common/params.stan
-  real<lower=1e-12> sigma[obs_model==1];
-  real<lower=1e-12> phi[obs_model==3];
-  real<lower=1e-12, upper=1-1e-12> gamma[obs_model==5];
+  array[obs_model==1] real<lower=1e-12> sigma;
+  array[obs_model==3] real<lower=1e-12> phi;
+  array[obs_model==5] real<lower=1e-12, upper=1-1e-12> gamma;
 }
 
 transformed parameters {


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax
- `fabs` replaced by `abs`
- `cov_exp_quad` replaced by `gp_exp_quad_cov`

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
